### PR TITLE
`Fix`: retain replacer when creating sub-handler

### DIFF
--- a/prettylog/prettylog.go
+++ b/prettylog/prettylog.go
@@ -50,11 +50,11 @@ func (h *Handler) Enabled(ctx context.Context, level slog.Level) bool {
 }
 
 func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return &Handler{h: h.h.WithAttrs(attrs), b: h.b, m: h.m}
+	return &Handler{h: h.h.WithAttrs(attrs), b: h.b, r: h.r, m: h.m}
 }
 
 func (h *Handler) WithGroup(name string) slog.Handler {
-	return &Handler{h: h.h.WithGroup(name), b: h.b, m: h.m}
+	return &Handler{h: h.h.WithGroup(name), b: h.b, r: h.r, m: h.m}
 }
 
 func (h *Handler) computeAttrs(


### PR DESCRIPTION
Currently, the handler panics when logging after using `WithGroup` or `WithAttrs` because the replacer is not retained in those methods.