### PR TITLE
Support destination writer and color disabling

### DIFF
--- a/prettylog/prettylog_test.go
+++ b/prettylog/prettylog_test.go
@@ -1,0 +1,32 @@
+package prettylog
+
+import (
+	"log/slog"
+	"regexp"
+	"testing"
+)
+
+type captureStream struct {
+	lines [][]byte
+}
+
+func (cs *captureStream) Write(bytes []byte) (int, error) {
+	cs.lines = append(cs.lines, bytes)
+	return len(bytes), nil
+}
+
+func Test_WritesToProvidedStream(t *testing.T) {
+	cs := &captureStream{}
+	handler := New(nil, WithDestinationWriter(cs))
+	logger := slog.New(handler)
+
+	logger.Info("testing logger")
+	if len(cs.lines) != 1 {
+		t.Errorf("expected 1 lines logged, got: %d", len(cs.lines))
+	}
+
+	lineMatcher := regexp.MustCompile(`\[\d{2}:\d{2}:\d{2}\.\d{3}\] INFO: testing logger {}`)
+	if lineMatcher.Match(cs.lines[0]) == false {
+		t.Errorf("expected `testing logger` but found `%s`", string(cs.lines[0]))
+	}
+}


### PR DESCRIPTION
👋 I woke up way too early this morning and had enough time to work on the feature we discussed.

This PR resolves #3. It adds a `New` function that will create a new handler while accepting a destination writer. It also accepts an option to enable colorizing output.

I went with the [functional options pattern][fop] as it is very common and works well.

The advertised default usage has not changed. That is, it still writes to `stdout` with colorized output by default when utilizing the `NewHandler` function to create the handler instance.

[fop]: https://golang.cafe/blog/golang-functional-options-pattern.html