### PR TITLE
#7 An empty body is output as `{}`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = tab
+indent_style = tab
+insert_final_newline = true
+max_line_length = 120
+tab_width = 2
+ij_smart_tabs = true

--- a/prettylog/prettylog_test.go
+++ b/prettylog/prettylog_test.go
@@ -18,7 +18,7 @@ func (cs *captureStream) Write(bytes []byte) (int, error) {
 
 func Test_WritesToProvidedStream(t *testing.T) {
 	cs := &captureStream{}
-	handler := New(nil, WithDestinationWriter(cs))
+	handler := New(nil, WithDestinationWriter(cs), WithOutputEmptyAttrs())
 	logger := slog.New(handler)
 
 	logger.Info("testing logger")
@@ -27,6 +27,26 @@ func Test_WritesToProvidedStream(t *testing.T) {
 	}
 
 	lineMatcher := regexp.MustCompile(`\[\d{2}:\d{2}:\d{2}\.\d{3}\] INFO: testing logger {}`)
+	line := string(cs.lines[0])
+	if lineMatcher.MatchString(line) == false {
+		t.Errorf("expected `testing logger` but found `%s`", line)
+	}
+	if !strings.HasSuffix(line, "\n") {
+		t.Errorf("exected line to be terminated with `\\n` but found `%s`", line[len(line)-1:])
+	}
+}
+
+func Test_SkipEmptyAttributes(t *testing.T) {
+	cs := &captureStream{}
+	handler := New(nil, WithDestinationWriter(cs))
+	logger := slog.New(handler)
+
+	logger.Info("testing logger")
+	if len(cs.lines) != 1 {
+		t.Errorf("expected 1 lines logged, got: %d", len(cs.lines))
+	}
+
+	lineMatcher := regexp.MustCompile(`\[\d{2}:\d{2}:\d{2}\.\d{3}\] INFO: testing logger`)
 	line := string(cs.lines[0])
 	if lineMatcher.MatchString(line) == false {
 		t.Errorf("expected `testing logger` but found `%s`", line)


### PR DESCRIPTION
fixed #7 

1. Added option to disable empty Attrs output
2. Added a minimal [editorconfig](https://editorconfig.org/) so that the IDE uses uniform project settings